### PR TITLE
fix: 폭발 유지시간 미적용 버그 해결

### DIFF
--- a/Assets/Resources/Prefab/Bomb.prefab
+++ b/Assets/Resources/Prefab/Bomb.prefab
@@ -19966,70 +19966,87 @@ MonoBehaviour:
   - {fileID: 1113351785514670152}
   - {fileID: 7466379078484346781}
   explosivePower: 1
-  explosionEffectContinuanceTime: 2.5
---- !u!1001 &7108916046651584769
-PrefabInstance:
+  explosionEffectContinuanceTime: 0.5
+--- !u!1 &7955213652920945744
+GameObject:
   m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 4864630041713910579}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: ffdfad76d2f7648d19c79be026141ab7, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ffdfad76d2f7648d19c79be026141ab7, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ffdfad76d2f7648d19c79be026141ab7, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ffdfad76d2f7648d19c79be026141ab7, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ffdfad76d2f7648d19c79be026141ab7, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ffdfad76d2f7648d19c79be026141ab7, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ffdfad76d2f7648d19c79be026141ab7, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ffdfad76d2f7648d19c79be026141ab7, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ffdfad76d2f7648d19c79be026141ab7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ffdfad76d2f7648d19c79be026141ab7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ffdfad76d2f7648d19c79be026141ab7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: ffdfad76d2f7648d19c79be026141ab7, type: 3}
-      propertyPath: m_Name
-      value: bomb
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: ffdfad76d2f7648d19c79be026141ab7, type: 3}
-      propertyPath: m_Layer
-      value: 7
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ffdfad76d2f7648d19c79be026141ab7, type: 3}
---- !u!4 &7290562569570391786 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: ffdfad76d2f7648d19c79be026141ab7, type: 3}
-  m_PrefabInstance: {fileID: 7108916046651584769}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7290562569570391786}
+  - component: {fileID: 5945476717283875151}
+  - component: {fileID: 8459559841824730501}
+  m_Layer: 7
+  m_Name: bomb
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7290562569570391786
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7955213652920945744}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4864630041713910579}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5945476717283875151
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7955213652920945744}
+  m_Mesh: {fileID: 145229435979250144, guid: ffdfad76d2f7648d19c79be026141ab7, type: 3}
+--- !u!23 &8459559841824730501
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7955213652920945744}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a563c4f0607b34794a3d5a88f6759ac9, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}

--- a/Assets/WorkSpace/DongyeonShin/Bomb.cs
+++ b/Assets/WorkSpace/DongyeonShin/Bomb.cs
@@ -14,20 +14,23 @@ public class Bomb : MonoBehaviour, IExplosiveReactivable
     private int explosivePower;
     [SerializeField]
     private float explosionEffectContinuanceTime;
+    private GameScene gameScene;
+    public GameScene GameScene { get { return gameScene; } set { gameScene = value; } }
     public int ExplosivePower { set { explosivePower = value; } }
     private LayerMask unPenetratedObjectsLayerMask;
     private LayerMask boxLayerMask;
     private BoxCollider bombCollider;
     private bool readyToExplode;
     private Coroutine lightTheFuseRoutine;
-    private GameScene gameScene;
-    public GameScene GameScene { get { return gameScene; } set { gameScene = value; } }
+    private MeshRenderer bombRenderer;
+
 
     private void Awake()
     {
         bombCollider = GetComponent<BoxCollider>();
         unPenetratedObjectsLayerMask = 1 | LayerMask.GetMask ("Bomb");
         boxLayerMask = LayerMask.GetMask("Box");
+        bombRenderer = GetComponentInChildren<MeshRenderer>();
     }
 
     private void OnEnable()
@@ -65,7 +68,12 @@ public class Bomb : MonoBehaviour, IExplosiveReactivable
         CheckObjectsInExplosionRange(Vector3.right);
         CheckObjectsInExplosionRange(Vector3.left);
         yield return null;
-        GameManager.Resource.Destroy(gameObject);
+        sparkParticle[0].gameObject.SetActive(false);
+        sparkParticle[1].gameObject.SetActive(false);
+        sparkParticle[2].gameObject.SetActive(false);
+        sparkParticle[3].gameObject.SetActive(false);
+        bombRenderer.enabled = false;
+        GameManager.Resource.Destroy(gameObject, explosionEffectContinuanceTime);
     }
 
     private void CheckObjectsInExplosionRange(Vector3 direction)
@@ -86,7 +94,7 @@ public class Bomb : MonoBehaviour, IExplosiveReactivable
                 if (gameScene != null)
                 {
                     gameScene.RequestExplosiveReaction(reactivableObject, this);
-                }   
+                }
                 if ((reactivableObjectLayerMask & unPenetratedObjectsLayerMask) > 0)
                 {
                     if (direction.z > 0)

--- a/Assets/WorkSpace/YoungsinLee/Scripts/DropBomb.cs
+++ b/Assets/WorkSpace/YoungsinLee/Scripts/DropBomb.cs
@@ -3,121 +3,121 @@ using Photon.Realtime;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
-public class DropBomb : MonoBehaviourPun, IEventListener, IExplosiveReactivable
-{
-    public int tastBomb;
+//public class DropBomb : MonoBehaviourPun, IEventListener, IExplosiveReactivable
+//{
+//    public int tastBomb;
 
 
-    private TestBomb bombPrefab;
-    private TestStat stat;
+//    private TestBomb bombPrefab;
+//    private TestStat stat;
 
-    private LayerMask de;
-    private Vector3 groundDir;
+//    private LayerMask de;
+//    private Vector3 groundDir;
 
-    private int curBomb;
-    private PlayerInput playerInput;
+//    private int curBomb;
+//    private PlayerInput playerInput;
 
-    private void Awake()
-    {
-        if (!photonView.IsMine)
-            Destroy(playerInput);
-        stat = GetComponent<TestStat>();
-        bombPrefab = GameManager.Resource.Load<TestBomb>("Bomb/Bomb");
-    }
+//    private void Awake()
+//    {
+//        if (!photonView.IsMine)
+//            Destroy(playerInput);
+//        stat = GetComponent<TestStat>();
+//        bombPrefab = GameManager.Resource.Load<TestBomb>("Bomb/Bomb");
+//    }
 
-    private void OnFire(InputValue value)
-    {
-         Drop();
-    }
+//    private void OnFire(InputValue value)
+//    {
+//         Drop();
+//    }
 
-    private void OnEnable()
-    {
-        curBomb = stat.Bomb;
-        GameManager.Event.AddListener(EventType.Explode, this);
-    }
+//    private void OnEnable()
+//    {
+//        curBomb = stat.Bomb;
+//        GameManager.Event.AddListener(EventType.Explode, this);
+//    }
 
-    private void CheckBomb()
-    {
-        if (stat.Bomb >= 6)
-            return;
-    }
+//    private void CheckBomb()
+//    {
+//        if (stat.Bomb >= 6)
+//            return;
+//    }
 
-    private Vector3 GroundChack()
-    {
-        RaycastHit hit;
-        Debug.DrawRay(transform.position + 0.3f * Vector3.up, Vector3.down * 0.8f, Color.red);
-        if (Physics.Raycast(transform.position + 0.3f * Vector3.up, Vector3.down, out hit, 0.8f))
-        {
-            if (hit.collider != null && hit.collider.gameObject != null)
-            {
-                groundDir = new Vector3(hit.collider.gameObject.transform.position.x, 0, hit.collider.gameObject.transform.position.z);
-                return groundDir;
-            }
-            else
-            {
-                Debug.Log("밑에 오브젝트가 암것도 없음");
-                return Vector3.zero;
-            }
-        }
-        else
-        {
-            Debug.Log("암것도 안부딪힘");
-            return Vector3.zero;
-        }
-    }
+//    private Vector3 GroundChack()
+//    {
+//        RaycastHit hit;
+//        Debug.DrawRay(transform.position + 0.3f * Vector3.up, Vector3.down * 0.8f, Color.red);
+//        if (Physics.Raycast(transform.position + 0.3f * Vector3.up, Vector3.down, out hit, 0.8f))
+//        {
+//            if (hit.collider != null && hit.collider.gameObject != null)
+//            {
+//                groundDir = new Vector3(hit.collider.gameObject.transform.position.x, 0, hit.collider.gameObject.transform.position.z);
+//                return groundDir;
+//            }
+//            else
+//            {
+//                Debug.Log("밑에 오브젝트가 암것도 없음");
+//                return Vector3.zero;
+//            }
+//        }
+//        else
+//        {
+//            Debug.Log("암것도 안부딪힘");
+//            return Vector3.zero;
+//        }
+//    }
 
-    private void Drop()
-    {
-        if (curBomb == 0)
-            return;
-        if(curBomb > stat.Bomb)
-            curBomb = stat.Bomb;
-        photonView.RPC("RequestCreateBomb", RpcTarget.MasterClient, transform.position, transform.rotation);
-        //GameManager.Resource.Instantiate(bomb, GroundChack(), transform.rotation);
-        curBomb--;
-        // 네트워크 식
-    }
+//    private void Drop()
+//    {
+//        if (curBomb == 0)
+//            return;
+//        if(curBomb > stat.Bomb)
+//            curBomb = stat.Bomb;
+//        photonView.RPC("RequestCreateBomb", RpcTarget.MasterClient, transform.position, transform.rotation);
+//        //GameManager.Resource.Instantiate(bomb, GroundChack(), transform.rotation);
+//        curBomb--;
+//        // 네트워크 식
+//    }
 
-    [PunRPC]
-    private void RequestCreateBomb(Vector3 position, Quaternion rotation, PhotonMessageInfo info)
-    {
-        float sentTime = (float)info.SentServerTime;
-        // 반장이 직접 판단하지 않고 서버를 한번 걸치는 식으로 서버를 통해 판단하게 설정(공평성을 위해)
-        photonView.RPC("ResultCreateBomb", RpcTarget.AllViaServer, position, rotation, sentTime, info.Sender);
+//    [PunRPC]
+//    private void RequestCreateBomb(Vector3 position, Quaternion rotation, PhotonMessageInfo info)
+//    {
+//        float sentTime = (float)info.SentServerTime;
+//        // 반장이 직접 판단하지 않고 서버를 한번 걸치는 식으로 서버를 통해 판단하게 설정(공평성을 위해)
+//        photonView.RPC("ResultCreateBomb", RpcTarget.AllViaServer, position, rotation, sentTime, info.Sender);
     
-    }
+//    }
 
 
-    [PunRPC]
-    private void ResultCreateBomb(Vector3 position, Quaternion rotation, float sentTime, Player player)
-    {
-        float lag = (float)(PhotonNetwork.Time - sentTime);
-        position = GroundChack();
-        Instantiate(bombPrefab, position, rotation); // 값을 정해서 보내면 더욱 정확한 타이밍을 맞출수있음
-        bombPrefab.SetPlayer(player);
-        Debug.Log($"{photonView.Owner.NickName}발싸!");
-    }
+//    [PunRPC]
+//    private void ResultCreateBomb(Vector3 position, Quaternion rotation, float sentTime, Player player)
+//    {
+//        float lag = (float)(PhotonNetwork.Time - sentTime);
+//        position = GroundChack();
+//        Instantiate(bombPrefab, position, rotation); // 값을 정해서 보내면 더욱 정확한 타이밍을 맞출수있음
+//        bombPrefab.SetPlayer(player);
+//        Debug.Log($"{photonView.Owner.NickName}발싸!");
+//    }
 
     
 
-    // 폭탄 폭발시 갯수 추가
-    public void OnEvent(EventType eventType, Component Sender, object Param = null)
-    {
-        if(EventType.Explode == eventType)
-        {
-            curBomb++;
-        }
-    }
+//    // 폭탄 폭발시 갯수 추가
+//    public void OnEvent(EventType eventType, Component Sender, object Param = null)
+//    {
+//        if(EventType.Explode == eventType)
+//        {
+//            curBomb++;
+//        }
+//    }
 
-    public void ExplosiveReact()
-    {
-        // 죽는 애니메이션 실행
+//    public void ExplosiveReact()
+//    {
+//        // 죽는 애니메이션 실행
         
-    }
+//    }
 
-    public void OnExitButtom()
-    {
-        PhotonNetwork.LeaveRoom();
-        PhotonNetwork.JoinLobby();
-    }
-}
+//    public void OnExitButtom()
+//    {
+//        PhotonNetwork.LeaveRoom();
+//        PhotonNetwork.JoinLobby();
+//    }
+//}


### PR DESCRIPTION
폭발 여파 진행 전 혹은 중에 폭탄을 회수해서 해당 스크립트가 작동하지 못하는 버그를 수정 (폭탄 랜더러만 끄고 여파가 다 진행된 후 회수)